### PR TITLE
Port to current `bats-core`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: bash
 env:
   - BATS_VERSION=v0.4.0
   - BATS_VERSION=v1.0.0
+  - BATS_VERSION=v1.0.1
 before_install:
   - ./script/install-bats.sh
   - git clone --depth 1 https://github.com/ztombol/bats-support ../bats-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
   - BATS_VERSION=v0.4.0
   - BATS_VERSION=v1.0.0
   - BATS_VERSION=v1.0.1
+  - BATS_VERSION=v1.0.2
 before_install:
   - ./script/install-bats.sh
   - git clone --depth 1 https://github.com/ztombol/bats-support ../bats-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: bash
+env:
+  - BATS_VERSION=v0.4.0
 before_install:
   - ./script/install-bats.sh
   - git clone --depth 1 https://github.com/ztombol/bats-support ../bats-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 before_script:
   - export PATH="${HOME}/.local/bin:${PATH}"
 script:
-  - if [ "${BATS_VERSION}" = "v1.0.0" ]; then ! bats test; else bats test; fi
+  - bats test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: bash
 env:
   - BATS_VERSION=v0.4.0
+  - BATS_VERSION=v1.0.0
 before_install:
   - ./script/install-bats.sh
   - git clone --depth 1 https://github.com/ztombol/bats-support ../bats-support
 before_script:
   - export PATH="${HOME}/.local/bin:${PATH}"
 script:
-  - bats test
+  - if [ "${BATS_VERSION}" = "v1.0.0" ]; then ! bats test; else bats test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   - BATS_VERSION=v1.0.0
   - BATS_VERSION=v1.0.1
   - BATS_VERSION=v1.0.2
+  - BATS_VERSION=v1.1.0
 before_install:
   - ./script/install-bats.sh
   - git clone --depth 1 https://github.com/ztombol/bats-support ../bats-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - BATS_VERSION=v1.0.1
   - BATS_VERSION=v1.0.2
   - BATS_VERSION=v1.1.0
+  - BATS_VERSION=master
 before_install:
   - ./script/install-bats.sh
   - git clone --depth 1 https://github.com/ztombol/bats-support ../bats-support

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o xtrace
 
-BATS_VERSION="${BATS_VERSION:-v1.0.0}"
+BATS_VERSION="${BATS_VERSION:-v1.0.1}"
 
 git clone \
   --branch "${BATS_VERSION}" \

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o xtrace
 
-BATS_VERSION="${BATS_VERSION:-v1.0.2}"
+BATS_VERSION="${BATS_VERSION:-v1.1.0}"
 
 git clone \
   --branch "${BATS_VERSION}" \

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o xtrace
 
-BATS_VERSION="${BATS_VERSION:-v0.4.0}"
+BATS_VERSION="${BATS_VERSION:-v1.0.0}"
 
 git clone \
   --branch "${BATS_VERSION}" \

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -2,10 +2,10 @@
 set -o errexit
 set -o xtrace
 
-BATS_VERSION="${1:-0.4.0}"
+BATS_VERSION="${BATS_VERSION:-v0.4.0}"
 
 git clone \
-  --branch "v${BATS_VERSION}" \
+  --branch "${BATS_VERSION}" \
   --depth 1 \
   https://github.com/bats-core/bats-core bats
 

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o xtrace
 
-BATS_VERSION="${BATS_VERSION:-v1.0.1}"
+BATS_VERSION="${BATS_VERSION:-v1.0.2}"
 
 git clone \
   --branch "${BATS_VERSION}" \

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o xtrace
 
-BATS_VERSION="${BATS_VERSION:-v1.1.0}"
+BATS_VERSION="${BATS_VERSION:-master}"
 
 git clone \
   --branch "${BATS_VERSION}" \

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -7,7 +7,7 @@ BATS_VERSION="${1:-0.4.0}"
 git clone \
   --branch "v${BATS_VERSION}" \
   --depth 1 \
-  https://github.com/sstephenson/bats
+  https://github.com/bats-core/bats-core bats
 
 (cd bats
   ./install.sh "${HOME}/.local"

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -2,7 +2,10 @@
 set -o errexit
 set -o xtrace
 
+BATS_VERSION="${1:-0.4.0}"
+
 git clone \
+  --branch "v${BATS_VERSION}" \
   --depth 1 \
   https://github.com/sstephenson/bats
 

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -2,5 +2,12 @@
 set -o errexit
 set -o xtrace
 
-git clone --depth 1 https://github.com/sstephenson/bats
-cd bats && ./install.sh "${HOME}/.local" && cd .. && rm -rf bats
+git clone \
+  --depth 1 \
+  https://github.com/sstephenson/bats
+
+(cd bats
+  ./install.sh "${HOME}/.local"
+)
+
+rm -rf bats

--- a/test/51-temp-10-temp_make.bats
+++ b/test/51-temp-10-temp_make.bats
@@ -42,16 +42,17 @@ fixtures 'temp'
 @test "temp_make() <var>: does not work when called from \`main'" {
   run bats "${TEST_FIXTURE_ROOT}/temp_make-main.bats"
 
-  if [[ "${BATS_VERSION}" =~ ^1\.2\.0 ]]
-  then
-    [ "$status" -ne 1 ]
-  else
   [ "$status" -eq 1 ]
-  [ "${#lines[@]}" -eq 3 ]
-  [ "${lines[0]}" == '-- ERROR: temp_make --' ]
-  [ "${lines[1]}" == "Must be called from \`setup', \`@test' or \`teardown'" ]
-  [ "${lines[2]}" == '--' ]
-  fi
+  [ "${#lines[@]}" -ge 3 ]
+
+  # Starting with `bats` commit 17e2cf35 "*: refactor to always use
+  # bats-exec-suite" (bats-core/bats-core@17e2cf35), an empty test is needed
+  # which emits an empty line as a side-effect, account for it.
+  declare -i i_line=$(( ${#lines[@]} - 3 ))
+
+  [ "${lines[$(( i_line++ ))]}" == '-- ERROR: temp_make --' ]
+  [ "${lines[$(( i_line++ ))]}" == "Must be called from \`setup', \`@test' or \`teardown'" ]
+  [ "${lines[$(( i_line++ ))]}" == '--' ]
 }
 
 # Options

--- a/test/51-temp-10-temp_make.bats
+++ b/test/51-temp-10-temp_make.bats
@@ -42,11 +42,16 @@ fixtures 'temp'
 @test "temp_make() <var>: does not work when called from \`main'" {
   run bats "${TEST_FIXTURE_ROOT}/temp_make-main.bats"
 
+  if [[ "${BATS_VERSION}" =~ ^1\.2\.0 ]]
+  then
+    [ "$status" -ne 1 ]
+  else
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- ERROR: temp_make --' ]
   [ "${lines[1]}" == "Must be called from \`setup', \`@test' or \`teardown'" ]
   [ "${lines[2]}" == '--' ]
+  fi
 }
 
 # Options

--- a/test/51-temp-11-temp_del.bats
+++ b/test/51-temp-11-temp_del.bats
@@ -96,11 +96,16 @@ fixtures 'temp'
   export TEST_TEMP_DIR
   run bats "${TEST_FIXTURE_ROOT}/temp_del-main.bats"
 
+  if [[ "${BATS_VERSION}" =~ ^1\.2\.0 ]]
+  then
+    [ "$status" -ne 1 ]
+  else
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- ERROR: temp_del --' ]
   [ "${lines[1]}" == "Must be called from \`teardown' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]
   [ "${lines[2]}" == '--' ]
+  fi
 }
 
 @test "temp_del() <path>: \`BATSLIB_TEMP_PRESERVE_ON_FAILURE' does not work when called from \`setup'" {

--- a/test/51-temp-11-temp_del.bats
+++ b/test/51-temp-11-temp_del.bats
@@ -96,16 +96,17 @@ fixtures 'temp'
   export TEST_TEMP_DIR
   run bats "${TEST_FIXTURE_ROOT}/temp_del-main.bats"
 
-  if [[ "${BATS_VERSION}" =~ ^1\.2\.0 ]]
-  then
-    [ "$status" -ne 1 ]
-  else
   [ "$status" -eq 1 ]
-  [ "${#lines[@]}" -eq 3 ]
-  [ "${lines[0]}" == '-- ERROR: temp_del --' ]
-  [ "${lines[1]}" == "Must be called from \`teardown' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]
-  [ "${lines[2]}" == '--' ]
-  fi
+  [ "${#lines[@]}" -ge 3 ]
+
+  # Starting with `bats` commit 17e2cf35 "*: refactor to always use
+  # bats-exec-suite" (bats-core/bats-core@17e2cf35), an empty test is needed
+  # which emits an empty line as a side-effect, account for it.
+  declare -i i_line=$(( ${#lines[@]} - 3 ))
+
+  [ "${lines[$(( i_line++ ))]}" == '-- ERROR: temp_del --' ]
+  [ "${lines[$(( i_line++ ))]}" == "Must be called from \`teardown' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]
+  [ "${lines[$(( i_line++ ))]}" == '--' ]
 }
 
 @test "temp_del() <path>: \`BATSLIB_TEMP_PRESERVE_ON_FAILURE' does not work when called from \`setup'" {

--- a/test/fixtures/temp/temp_del-main.bats
+++ b/test/fixtures/temp/temp_del-main.bats
@@ -4,3 +4,6 @@ load 'test_helper'
 
 BATSLIB_TEMP_PRESERVE_ON_FAILURE=1
 temp_del "$TEST_TEMP_DIR"
+
+@test "void" {
+}

--- a/test/fixtures/temp/temp_make-main.bats
+++ b/test/fixtures/temp/temp_make-main.bats
@@ -3,3 +3,6 @@
 load 'test_helper'
 
 TEST_TEMP_DIR="$(temp_make)"
+
+@test "void" {
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -10,7 +10,12 @@
 #   none
 fixtures() {
   TEST_FIXTURE_ROOT="${BATS_TEST_DIRNAME}/fixtures/$1"
-  TEST_RELATIVE_FIXTURE_ROOT="$(bats_trim_filename "${TEST_FIXTURE_ROOT}")"
+  if bats_trim_filename "${TEST_FIXTURE_ROOT}" &>/dev/null
+  then
+    TEST_RELATIVE_FIXTURE_ROOT="$(bats_trim_filename "${TEST_FIXTURE_ROOT}")"
+  else
+    bats_trim_filename "${TEST_FIXTURE_ROOT}" TEST_RELATIVE_FIXTURE_ROOT
+  fi
 }
 
 setup() {


### PR DESCRIPTION
The original [`bats` repository](https://github.com/sstephenson/bats) is abandoned (no commits for years), the successor being [`bats-core`](https://github.com/bats-core/bats-core). Over years, its development progressed, yet `bats-file` didn't follow, so now tests are failing due to a couple internal changes.

Luckily, fixing the tests is all that's needed, business logic isn't affected by the dependency upgrade.

To ensure backward compatibility to the old `bats`, additional `travis` environments were added so that a bunch of `bats-core` versions are tested at once, [v0.4.0](https://github.com/bats-core/bats-core/releases/tag/v0.4.0) being same as the latest `bats` release and the oldest version to be supported.