### PR TITLE
fix: #12 use short options -d and -p for --directory and --tmp-dir

### DIFF
--- a/src/temp.bash
+++ b/src/temp.bash
@@ -99,7 +99,7 @@ temp_make() {
   template+='-XXXXXXXXXX'
 
   local path
-  path="$(mktemp --directory --tmpdir="$BATS_TMPDIR" -- "$template" 2>&1)"
+  path="$(mktemp -d -p="$BATS_TMPDIR" -- "$template" 2>&1)"
   if (( $? )); then
     echo "$path" \
       | batslib_decorate 'ERROR: temp_make' \


### PR DESCRIPTION
## :question: Why ?

> It makes `temp_make` compatible with other distribution

## :panda_face: how ?

> By using short options instead of long options
